### PR TITLE
Fix markdown's reparse function

### DIFF
--- a/stdplugins/markdown.py
+++ b/stdplugins/markdown.py
@@ -70,9 +70,9 @@ MATCHERS = [
 ]
 
 
-def parse(message, old_entities=[]):
+def parse(message, old_entities=None):
     entities = []
-    old_entities = {e.offset: e for e in old_entities}
+    old_entities = {e.offset: e for e in old_entities or []}
 
     i = 0
     message = _add_surrogate(message)


### PR DESCRIPTION
Instead of unparsing the message and then parsing it again, it now skips existing entities. This lets it ignore things like __ in urls/mentions.