### PR TITLE
Add help commands for bots

### DIFF
--- a/uniborg/_core.py
+++ b/uniborg/_core.py
@@ -61,3 +61,29 @@ async def list_plugins(event):
         await event.edit(result)
     else:
         await event.respond(result)
+
+
+@borg.on(borg.cmd(r"help(?: (?P<shortname>\w+))?"))
+async def help(event):
+    if not borg.me.bot:
+        return
+
+    shortname = event.pattern_match["shortname"]
+    plugin_dict = {}
+
+    for name, mod in sorted(borg._plugins.items(), key=lambda t: t[0]):
+        if name == "_core":
+            continue
+        desc = (mod.__doc__ or "No Description")
+        plugin_dict[name] = desc
+
+    plugin_list = "`\n• `".join(plugin_dict)
+
+    if not shortname:
+        result = f"**Plugins:** \
+                   \n• `{plugin_list}` \
+                   \n\nSend `/help plugin_name` for more information."
+    else:
+        result = plugin_dict[shortname]
+
+    await event.reply(result)

--- a/uniborg/_core.py
+++ b/uniborg/_core.py
@@ -50,22 +50,10 @@ async def remove(event):
         await borg.delete_messages(msg.to_id, msg)
 
 
-@borg.on(borg.admin_cmd(r"plugins"))
-async def list_plugins(event):
-    result = f'{len(borg._plugins)} plugins loaded:'
-    for name, mod in sorted(borg._plugins.items(), key=lambda t: t[0]):
-        desc = (mod.__doc__ or '__no description__').replace('\n', ' ').strip()
-        result += f'\n**{name}**: {desc}'
-
-    if not borg.me.bot:
-        await event.edit(result)
-    else:
-        await event.respond(result)
-
-
+@borg.on(borg.cmd(r"plugins?(?: (?P<shortname>\w+))?"))
 @borg.on(borg.cmd(r"help(?: (?P<shortname>\w+))?"))
 async def help(event):
-    if not borg.me.bot:
+    if borg.me.bot and not event.is_private:
         return
 
     shortname = event.pattern_match["shortname"]
@@ -80,10 +68,16 @@ async def help(event):
     plugin_list = "`\n• `".join(plugin_dict)
 
     if not shortname:
-        result = f"**Plugins:** \
-                   \n• `{plugin_list}` \
-                   \n\nSend `/help plugin_name` for more information."
+        result = f"**Plugins:**  "
+        if not borg.me.bot:
+            result += str(len(borg._plugins))
+
+        result += f"\n• `{plugin_list}` \
+                  \n\nSend `/help plugin_name` for more information."
     else:
         result = plugin_dict[shortname]
 
-    await event.reply(result)
+    if not borg.me.bot:
+        await event.edit(result)
+    else:
+        await event.reply(result)


### PR DESCRIPTION
This creates a formatted list of plugins (excluding `_core`) when sending `/help`, and message with the plugin description when sending `/help plugin_name`